### PR TITLE
Better info of arguments through "OPTIONS" request

### DIFF
--- a/wp-includes/rest-api/class-wp-rest-server.php
+++ b/wp-includes/rest-api/class-wp-rest-server.php
@@ -1064,6 +1064,12 @@ class WP_REST_Server {
 					if ( isset( $opts['default'] ) ) {
 						$arg_data['default'] = $opts['default'];
 					}
+					if ( isset( $opts['enum'] ) ) {
+						$arg_data['enum'] = $opts['enum'];
+					}
+					if ( isset( $opts['description'] ) ) {
+						$arg_data['description'] = $opts['description'];
+					}
 					$endpoint_data['args'][ $key ] = $arg_data;
 				}
 			}


### PR DESCRIPTION
It would be nice to be a little more explicit about the values available to filter requests. For instance, to let user to know which kind of values are available for the request arguments through the OPTIONS HTTP verb.
